### PR TITLE
ci: run firmware builds for pull request updates

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-    types: [closed]
+    types: [opened, synchronize, reopened]
   release:
     types: [ created ]
 


### PR DESCRIPTION
Enable the aggregate firmware-build workflow as soon as a PR is opened and whenever it is updated or reopened.

This restores pre-merge validation for board-specific firmware changes, including PR #22.